### PR TITLE
Added mode param to /api/gemini endpoint

### DIFF
--- a/app/api/gemini/route.js
+++ b/app/api/gemini/route.js
@@ -6,10 +6,32 @@ dotenv.config()
 const geminiURL = process.env.NEXT_PUBLIC_GEMINI_URL
 const apiKey = process.env.NEXT_PUBLIC_API_KEY
 
+const constructPrompt = (brandName) => {
+  return `What country is the brand "${brandName}" from? If the brand name is unrecognized or the country cannot be determined, 
+  return "Unknown" for the country. Respond strictly in the following JSON format, with no additional text before or after the JSON:
+  {
+    "country": "{country or 'Unknown'}", 
+    "list": ["alternative product from Canada 1", "alternative product from Canada 2", ... up to 5]
+  }`;
+};
+
 export async function POST(request) {
-  console.log("im in geminiResponse")
+  console.log("im in gemini")
   try {
-    const { prompt } = await request.json()
+    let { prompt } = await request.json()
+    const { searchParams } = new URL(request.url);
+    const mode = searchParams.get("mode");
+
+    if (!mode || (mode !== "scan" && mode !== "chat")) {
+      return NextResponse.json({ error: "Invalid mode. Use 'scan' or 'chat'." }, { status: 400 });
+    }
+
+    if (mode === "scan") {
+      prompt = constructPrompt(prompt);
+    }
+
+    console.log(prompt);
+
     const body = {
       contents: [
         {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,7 +21,7 @@ export default function HomePage() {
     }
 
     try {
-      const response = await fetch(`./api/geminiResponse`, {
+      const response = await fetch(`./api/gemini?mode=chat`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
Added mode param to `/api/gemini` endpoint.

1. `mode=scan`
When we want to send Gemini the brand name, call `/api/gemini?mode=scan`
Response format:
```json
{
  "country": "Unknown",
  "list": ["President's Choice", "PC Organics", "Loblaws", "No Name", "Maple Leaf Foods"]
}
```

2. `mode=chat`
When we want to send Gemini the exact input from the chat box, call `/api/gemini?mode=chat`.
Response format:
"I am doing well, thank you for asking!  How are you today?"